### PR TITLE
Build static and shared libs in Makefile

### DIFF
--- a/Makefile.unix
+++ b/Makefile.unix
@@ -49,6 +49,8 @@ TESTS = $(patsubst %.c, build/%, $(TSOURCES))
 
 BINARIES = __BINARIES__ $(TESTS)
 
+LIBRARIES = __LIBRARIES__ dist/lib/libbsdnt.a dist/lib/libbsdnt.so
+
 # PROFILE FILES
 PSOURCES = __PSOURCES__
 
@@ -59,6 +61,8 @@ PROFS = $(patsubst %.c, build/%, $(PSOURCES))
 
 # RULES
 all: $(OBJS) $(BINARIES)
+
+dist: $(LIBRARIES)
 
 clean:
 	rm -f $(OBJS) $(BINARIES)
@@ -76,6 +80,12 @@ strip:
 	strip $(BINARIES)
 
 profile: $(OBJS) $(PROFS)
+
+dist/lib/libbsdnt.a: $(OBJS)
+	$(QUIET_AR)$(AR) rcs $@ $(OBJS)
+
+dist/lib/libbsdnt.so: $(OBJS)
+	$(QUIET_CC)$(CC) -shared $(OBJS) -lm -o $@
 
 build/arch/%.o: %.asm
 	$(QUIET_AS)$(AS)  $(AFLAGS) $< -o $@

--- a/configure
+++ b/configure
@@ -223,7 +223,8 @@ sed_makefile()
     sed "s|__TESTS__|${TESTS}|g" Makefile.tmp > Makefile
     sed "s|__PSOURCES__|${PFILES}|g" Makefile > Makefile.tmp
     sed "s|__BINARIES__|${BINARIES}|g" Makefile.tmp > Makefile
-    rm Makefile.tmp
+    sed "s|__LIBRARIES__|${LIBRARIES}|g" Makefile > Makefile.tmp
+    mv Makefile.tmp Makefile
 }
 
 


### PR DESCRIPTION
I was trying to create an AUR package for arch and realized that currently the Makefile does not build any libraries. I think this is what you were going for with the `dist` rule.
