### PR TITLE
Fix installation of headers

### DIFF
--- a/Makefile.unix
+++ b/Makefile.unix
@@ -41,6 +41,7 @@ QUIET_SO         = @echo '   ' SO '   ' $@;
 # FILES
 SOURCES = __SOURCES__
 HEADERS = __HEADERS__
+ARCHHEADERS = __ARCHHEADERS__
 OBJS = $(patsubst %.c, build/%.o, $(SOURCES))
 
 # TEST FILES
@@ -76,8 +77,10 @@ check: $(OBJS) $(BINARIES)
 	$(foreach prog, $(TESTS), $(prog);)	
 
 install:
+	mkdir -p $(PREFIX)/lib $(PREFIX)/include/bsdnt/arch/inline
 	cp $(LIBRARIES) $(PREFIX)/lib
-	cp $(HEADERS) $(PREFIX)/include
+	cp $(HEADERS) $(PREFIX)/include/bsdnt
+	cp $(ARCHHEADERS) $(PREFIX)/include/bsdnt/arch/inline
 
 strip:
 	strip $(BINARIES)

--- a/configure
+++ b/configure
@@ -388,6 +388,7 @@ fill_makefile_wireframe()
 
     CFILESARR=`ls -1 *.c rand/*.c`
     HFILESARR=`ls -1 *.h`
+    ARCHHFILESARR=`ls -1 arch/inline/*.h`
     TFILESARR=`ls -1 test/t-*.c`
     PFILESARR=`ls -1 profile/p-*.c`
 
@@ -399,6 +400,11 @@ fill_makefile_wireframe()
     for H in `echo ${HFILESARR[*]}`;
     do
         HFILES="$HFILES $H"
+    done
+
+    for AH in `echo ${ARCHHFILESARR[*]}`;
+    do
+        ARCHHFILES="$ARCHHFILES $AH"
     done
 
     for T in `echo ${TFILESARR[*]}`;
@@ -433,7 +439,8 @@ sed_makefile()
     sed "s|__BINARIES__|${BINARIES}|g" Makefile.tmp > Makefile
     sed "s|__LIBRARIES__|${LIBRARIES}|g" Makefile > Makefile.tmp
     sed "s|__PREFIX__|${PREFIX}|g" Makefile.tmp > Makefile
-    rm Makefile.tmp
+    sed "s|__ARCHHEADERS__|${ARCHHFILES}|g" Makefile > Makefile.tmp
+    mv Makefile.tmp Makefile
 }
 
 
@@ -456,10 +463,10 @@ create_config_h
 os_handler
 arch_handler
 defaults
+create_types_arch_h
 fill_makefile_wireframe
 sed_makefile
 make_directory_structure
-create_types_arch_h
 
 echo "Done. "
 echo " "


### PR DESCRIPTION
This is a first attempt at fixing issue #3.

What I've done is specifically
- Move `create_types_arch_h` before `fill_makefile_wireframe` so that `types_arch.h` gets included in the `HEADERS` array.
- Add a second `ARCHHEADERS` array for the headers in `arch/inline`.
- Change the location where headers are installed to from `$(PREFIX)/include` to `$(PREFIX)/include/bsdnt`. This prevents naming collisions from generically-named headers like `config.h` and `sha1.h`. 
