### PR TITLE
Fix warning on strcmp

### DIFF
--- a/arch/cpuid.c
+++ b/arch/cpuid.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
+#include <string.h>
 
 typedef struct bsdnt_cpuid_t
 {


### PR DESCRIPTION
Fixes a warning that clang emits.
