### PR TITLE
Fix typo in Makefile on Mac OS X

### DIFF
--- a/Makefile.unix
+++ b/Makefile.unix
@@ -93,7 +93,7 @@ libbsdnt.a: $(OBJS)
 libbsdnt.so: $(OBJS)
 	$(QUIET_CC)$(CC) -shared $(OBJS) -lm -o $@
 
-libsdnt.dylib: $(OBJS)
+libbsdnt.dylib: $(OBJS)
 	$(QUIET_CC)$(CC) -shared $(OBJS) -lm -o $@
 
 libbsdnt.dll: $(OBJS)


### PR DESCRIPTION
A small typo in the Makefile stops the library building on mac os x