### PR TITLE
Fixes to support a 32-bit word_t.

### DIFF
--- a/helper.h
+++ b/helper.h
@@ -62,7 +62,7 @@ typedef long bits_t;
 #define LEN_MAX LONG_MAX
 #define BITS_MAX LONG_MAX
 
-#define WORD_FMT "%l"
+#define WORD_FMT "%lu"
 #define LEN_FMT "%ld"
 #define BITS_FMT "%ld"
 
@@ -170,9 +170,17 @@ void talker(const char * str);
 
 #ifndef HAVE_ARCH_INTRINSICS
 
+#if WORD_BITS == 32
+#define high_zero_bits __builtin_clz
+#define low_zero_bits __builtin_ctz
+#define popcount_bits __builtin_popcount
+#elif WORD_BITS == 64
 #define high_zero_bits __builtin_clzl
 #define low_zero_bits __builtin_ctzl
 #define popcount_bits __builtin_popcountl
+#else
+#error "Unsupported WORD_BITS"
+#endif
 
 #endif
 

--- a/nn_quadratic.c
+++ b/nn_quadratic.c
@@ -250,7 +250,7 @@ void nn_divrem_classical_preinv_c(nn_t q, nn_t a, len_t m, nn_src_t d,
    ASSERT(n > 1);
    ASSERT((ci < d1) 
       || ((ci == d1) && (nn_cmp_m(a + m - n + 1, d, n - 1) < 0)));
-   ASSERT((long) d1 < 0);
+   ASSERT((sword_t) d1 < 0);
 
    a += m;
 
@@ -319,7 +319,7 @@ word_t nn_divapprox_classical_preinv_c(nn_t q, nn_t a, len_t m, nn_src_t d,
    ASSERT(n > 1);
    ASSERT((ci < d1) 
       || ((ci == d1) && (nn_cmp_m(a + m - n + 1, d, n - 1) < 0)));
-   ASSERT((long) d1 < 0);
+   ASSERT((sword_t) d1 < 0);
 
    a += m;
 

--- a/nn_subquadratic.c
+++ b/nn_subquadratic.c
@@ -471,7 +471,7 @@ word_t nn_divapprox_divconquer_preinv_c(nn_t q, nn_t a, len_t m, nn_src_t d,
    ASSERT(n >= 2);
    ASSERT((ci < d[n - 1]) 
       || ((ci == d[n - 1]) && (nn_cmp_m(a + m - n + 1, d, n - 1) < 0)));
-   ASSERT((long) d[n - 1] < 0);
+   ASSERT((sword_t) d[n - 1] < 0);
 
    /* special case, s <= 3 */
    if (s <= 3 || n <= 5) return nn_divapprox_classical_preinv_c(q, a, m, d, n, dinv, ci);
@@ -545,7 +545,7 @@ void nn_divrem_divconquer_preinv_c(nn_t q, nn_t a, len_t m, nn_src_t d,
    ASSERT(n >= 2);
    ASSERT((ci < d[n - 1]) 
       || ((ci == d[n - 1]) && (nn_cmp_m(a + m - n + 1, d, n - 1) < 0)));
-   ASSERT((long) d[n - 1] < 0);
+   ASSERT((sword_t) d[n - 1] < 0);
 
    /* Base case */
    if (n <= 3 || s <= 1)
@@ -605,7 +605,7 @@ void nn_div_divconquer_preinv_c(nn_t q, nn_t a, len_t m, nn_src_t d,
    ASSERT(n >= 2);
    ASSERT((ci < d[n - 1]) 
       || ((ci == d[n - 1]) && (nn_cmp_m(a + m - n + 1, d, n - 1) < 0)));
-   ASSERT((long) d[n - 1] < 0);
+   ASSERT((sword_t) d[n - 1] < 0);
 
    TMP_START;
    

--- a/test.c
+++ b/test.c
@@ -74,13 +74,13 @@ void free_redzoned_nn(nn_t a, len_t n)
       if (redzone1[i] != REDZONE_BYTE)
       {
          fprintf(stderr, "Underrun detected in nn_t at %p of "
-         "length %ld at byte %ld\n", (void *) a, n, i);
+         "length " LEN_FMT " at byte %ld\n", (void *) a, n, i);
          abort();
       }
       if (redzone2[i] != REDZONE_BYTE)
       {
          fprintf(stderr, "Overrun detected in nn_t at %p of "
-         "length %ld at byte %ld\n", (void *) a, n, i);
+         "length " LEN_FMT " at byte %ld\n", (void *) a, n, i);
          abort();
       }
    }

--- a/test/t-nn_quadratic.c
+++ b/test/t-nn_quadratic.c
@@ -198,7 +198,7 @@ int test_divrem_classical_preinv(void)
 
       if (!result) 
       {
-         printf("inv = %lu\n", inv);
+         printf("inv = " WORD_FMT "\n", inv);
          print_debug(a, m); print_debug(q, m); print_debug(d, n);  print_debug(r1, n);
          print_debug_diff(q, a, m);
       }


### PR DESCRIPTION
The core algorithms generally did not need any changes, but there were a a few assertions, print statements, and #defines needing tweaks.

To test this, I used the following types_arch.h:

    // types_arch.h
    #define HAVE_ARCH_types

    typedef unsigned int word_t;
    typedef int sword_t;
    typedef int len_t;
    typedef int bits_t;

    #define LEN_MAX INT_MAX
    #define BITS_MAX INT_MAX

    #define WORD_FMT "%u"
    #define LEN_FMT "%d"
    #define BITS_FMT "%d"

    typedef unsigned long long dword_t;
    #define WORD_BITS 32
    #define WORD(x) (x##U)